### PR TITLE
Better command args for ioquake3 and quake3e to be at screen resolution

### DIFF
--- a/metadata/packages.json
+++ b/metadata/packages.json
@@ -65,10 +65,6 @@
             {
                 "name": "ioquake3",
                 "command": "./ioquake3.x86_64",
-                "command_args": [
-                    "+r_mode",
-                    "-2"
-                ],
                 "download": [
                     "ioquake3"
                 ]
@@ -76,10 +72,6 @@
             {
                 "name": "quake3e",
                 "command": "./quake3e.x64",
-                "command_args": [
-                    "+r_mode",
-                    "-2"
-                ],
                 "download": [
                     "quake3e"
                 ]

--- a/metadata/packages.json
+++ b/metadata/packages.json
@@ -65,6 +65,12 @@
             {
                 "name": "ioquake3",
                 "command": "./ioquake3.x86_64",
+                "command_args": [
+                    "+set r_mode",
+                    "-2",
+                    "+set r_modeFullscreen",
+                    "-2"
+                ],
                 "download": [
                     "ioquake3"
                 ]
@@ -72,6 +78,12 @@
             {
                 "name": "quake3e",
                 "command": "./quake3e.x64",
+                "command_args": [
+                    "+set r_mode",
+                    "-2",
+                    "+set r_modeFullscreen",
+                    "-2"
+                ],
                 "download": [
                     "quake3e"
                 ]
@@ -794,7 +806,9 @@
                 "name": "ioquake3",
                 "command": "./ioquake3.x86_64",
                 "command_args": [
-                    "+r_mode",
+                    "+set r_mode",
+                    "-2",
+                    "+set r_modeFullscreen",
                     "-2"
                 ],
                 "download": [
@@ -806,7 +820,9 @@
                 "name": "quake3e",
                 "command": "./quake3e.x64",
                 "command_args": [
-                    "+r_mode",
+                    "+set r_mode",
+                    "-2",
+                    "+set r_modeFullscreen",
                     "-2"
                 ],
                 "download": [


### PR DESCRIPTION
~~The command argument `r_mode -2` for both ioquake3 and quake3e is redundant given that it's the default mode when the config file is created (in `~/.q3e`). It also skips the logo which is not an expected behavior (because the in-game console is triggered at every launch to set of the command arg).~~

1/ It's better to use the command (for example) `+set r_mode -2` instead of `+r_mode -2`, the first one will set the arg before launching the game, it's not necessary to restart the game and it doesn't skip the logo (unless with the specific command)

2/ ioquake3 and quake3e don't have the same default modes when it comes to mods, which Team Arena is one of them:

ioquake3 with `+set fs_game missionpack` by default:
`r_mode 3`
`r_modefullscreen` not present

quake3e with `+set fs_game missionpack` by default:
`r_mode 3`
`r_modefullscreen -2`

To ensure to be always at screen resolution by default with the main game and its mods, I think the best way is to use the command args `+set r_mode -2 +set r_modeFullscreen -2`. If the user wants something different, it remains possible to do it in the launch option of the game in Steam.

<!-- You can remove any parts of this template that do not apply to your changes -->

### New Engine Package Submissions

* [x] Have you followed the instructions in the build documentation?
* [x] Have you run the build locally and ensured the package allowed you to launch and play the Steam game?
* [x] Have you updated the packages.json file?
* [x] Have you ensured that there is not already a pull request or active engine package for the one you are adding?


### Common Code Submissions

* [x] Have you verified that the changes are isolated to the features or fixes you are wanting to do?
* [x] Have you tested at least one of the engines to ensure that your changes do not break existing workflow?
* [x] Have you described what your changes are accomplishing? 
