### PR TITLE
Missing line breaks in command args in ioquake3 & quake3e

### DIFF
--- a/metadata/packages.json
+++ b/metadata/packages.json
@@ -66,9 +66,8 @@
                 "name": "ioquake3",
                 "command": "./ioquake3.x86_64",
                 "command_args": [
-                    "+set r_mode",
-                    "-2",
-                    "+set r_modeFullscreen",
+                    "+set",
+                    "r_mode",
                     "-2"
                 ],
                 "download": [
@@ -79,9 +78,11 @@
                 "name": "quake3e",
                 "command": "./quake3e.x64",
                 "command_args": [
-                    "+set r_mode",
+                    "+set",
+                    "r_mode",
                     "-2",
-                    "+set r_modeFullscreen",
+                    "+set",
+                    "r_modeFullscreen",
                     "-2"
                 ],
                 "download": [
@@ -806,9 +807,8 @@
                 "name": "ioquake3",
                 "command": "./ioquake3.x86_64",
                 "command_args": [
-                    "+set r_mode",
-                    "-2",
-                    "+set r_modeFullscreen",
+                    "+set",
+                    "r_mode",
                     "-2"
                 ],
                 "download": [
@@ -820,9 +820,11 @@
                 "name": "quake3e",
                 "command": "./quake3e.x64",
                 "command_args": [
-                    "+set r_mode",
+                    "+set",
+                    "r_mode",
                     "-2",
-                    "+set r_modeFullscreen",
+                    "+set",
+                    "r_modeFullscreen",
                     "-2"
                 ],
                 "download": [


### PR DESCRIPTION
I forgot to add line breaks, so here's the fix.

I also delete `r_modeFullscreen` in ioquake3 because this arg doesn't exist in this engine.

<!-- You can remove any parts of this template that do not apply to your changes -->

### New Engine Package Submissions

* [x] Have you followed the instructions in the build documentation?
* [x] Have you run the build locally and ensured the package allowed you to launch and play the Steam game?
* [x] Have you updated the packages.json file?
* [x] Have you ensured that there is not already a pull request or active engine package for the one you are adding?


### Common Code Submissions

* [x] Have you verified that the changes are isolated to the features or fixes you are wanting to do?
* [x] Have you tested at least one of the engines to ensure that your changes do not break existing workflow?
* [x] Have you described what your changes are accomplishing? 
