### PR TITLE
packages.json | License Information

### DIFF
--- a/metadata/packages.json
+++ b/metadata/packages.json
@@ -2041,7 +2041,7 @@
             "author": "d10sfan",
             "author_link": "https://github.com/d10sfan",
             "license": "Unknown",
-            "license_link": "https://github.com/GTAmodding/re3/blob/master/README.md",
+            "license_link": "https://github.com/GTAmodding/re3/issues/794",
             "non_free": true
         }
     },
@@ -2064,7 +2064,7 @@
             "author": "d10sfan",
             "author_link": "https://github.com/d10sfan",
             "license": "Unknown",
-            "license_link": "https://github.com/GTAmodding/re3/blob/master/README.md",
+            "license_link": "https://github.com/GTAmodding/re3/issues/794",
             "non_free": true
         }
     },
@@ -2328,7 +2328,7 @@
             "author": "d10sfan",
             "author_link": "https://github.com/d10sfan",
             "license": "Unknown",
-            "license_link": "https://github.com/AliveTeam/alive_reversing/blob/master/README.md",
+            "license_link": "https://github.com/AliveTeam/alive_reversing/issues/1083",
             "non_free": true
         }
     },
@@ -2352,7 +2352,7 @@
             "author": "d10sfan",
             "author_link": "https://github.com/d10sfan",
             "license": "Unknown",
-            "license_link": "https://github.com/AliveTeam/alive_reversing/blob/master/README.md",
+            "license_link": "https://github.com/AliveTeam/alive_reversing/issues/1083",
             "non_free": true
         }
     },
@@ -2589,7 +2589,7 @@
             "author": "d10sfan",
             "author_link": "https://github.com/d10sfan",
             "license": "Unknown",
-            "license_link": "https://github.com/Rubberduckycooly/Sonic-CD-11-Decompilation",
+            "license_link": "https://github.com/Rubberduckycooly/Sonic-CD-11-Decompilation/issues/77",
             "non_free": true
         }
     },
@@ -3381,7 +3381,9 @@
             "version": "",
             "comments": "Using Linux version bundled with Windows version",
             "author": "dreamer",
-            "author_link": "https://github.com/dreamer"
+            "author_link": "https://github.com/dreamer",
+            "license": "MIT, LGPLv2.1 and other free/libre/open source licenses",
+            "license_link": "https://www.renpy.org/doc/html/license.html"
         }
     },
     "812440": {


### PR DESCRIPTION
Replacing `"license_link"` for engines *re3/reVC*, *alive\_reversing* and *Sonic-CD-11-Decompilation*  that have their license marked as `"Unknown"`. Original `"license_link"` goes to README files that provide no information about licensing. The **new links** go to issue for each engine, where the missing license is discussed.

Also adding license information about *Ren'Py* engine, together with the relevant link.

<!-- You can remove any parts of this template that do not apply to your changes -->

### Common Code Submissions

Hopefully, these changes are minor enough that verification and testing is not required. If you think otherwise, let me know and I might try to verify.

* [ ] Have you tested at least one of the engines to ensure that your changes do not break existing workflow?
* [ ] Have you verified that the changes are isolated to the features or fixes you are wanting to do?
* [x] Have you described what your changes are accomplishing? 
