### PR TITLE
Dynamic library build

### DIFF
--- a/.github/workflows/test_library.yml
+++ b/.github/workflows/test_library.yml
@@ -1,0 +1,37 @@
+name: Build Library
+
+on:
+  pull_request:
+    paths:
+      - 'libraries/**'
+
+jobs:
+  findengine:
+    runs-on: ubuntu-latest
+    outputs:
+      engine: ${{ steps.findname.outputs.engine }}
+      container: ${{ steps.findname.outputs.container }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v1
+    - name: Find Library Name
+      id: findname
+      uses: luxtorpeda-dev/action-build-get-engine-name@v5
+      with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+  build:
+    runs-on: ubuntu-latest
+    needs: findengine
+    container: ${{ needs.findengine.outputs.container }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v1
+    - name: Build
+      run: ./common/start_build.sh ${{needs.findengine.outputs.engine}}
+    - name: Package
+      run: ./common/package.sh ${{needs.findengine.outputs.engine}}
+    - name: Upload Artifacts
+      uses: actions/upload-artifact@v1
+      with:
+        name: dist
+        path: ./dist

--- a/libraries/steam-runtime/boost-headers/build.sh
+++ b/libraries/steam-runtime/boost-headers/build.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+readonly pfx="$PWD/local"
+mkdir -p "$pfx"
+
+# CLONE PHASE
+git clone https://github.com/boostorg/boost boost
+pushd boost
+git checkout -f 68a24986
+git submodule update --init --recursive
+popd
+
+# BUILD PHASE
+pushd "boost"
+./bootstrap.sh
+./b2 headers --prefix="$pfx"
+popd
+
+
+# COPY PHASE
+cp -rfv "$pfx"/* "$diststart/common/dist/"

--- a/libraries/steam-runtime/boost-headers/build.sh
+++ b/libraries/steam-runtime/boost-headers/build.sh
@@ -6,7 +6,7 @@ mkdir -p "$pfx"
 # CLONE PHASE
 git clone https://github.com/boostorg/boost boost
 pushd boost
-git checkout -f 68a24986
+git checkout -f b7b1371
 git submodule update --init --recursive
 popd
 

--- a/libraries/steam-runtime/boost-headers/env.sh
+++ b/libraries/steam-runtime/boost-headers/env.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+export STEAM_APP_ID_LIST=""
+export LICENSE_PATH="./boost/LICENSE_1_0.txt"
+export COMMON_PACKAGE="1"


### PR DESCRIPTION
* libraries folder in packages repo with folders for each build env (steam-runtime, ubuntu-1804, 32-bit, etc)
* new workflows for libraries folders with its own metadata/libraries.json to keep track of possible libraries
* chained deps would request the built library (if standalone) in env, then those deps would be provided in the final artifact
* engines would have in env request to use these packages, nodejs workflow would be created to look those up and provide download array that the start_build script would use to put into "$pfx_libs" folder that would be included by engine build step
* workflow that updates the download area in packages.json would also update the downloads array with libraries, with library true for download so it knows to overwrite all of them. would also need a way to handle games with custom extraction areas, or multiple engines supported in one game. Either this or bundle all of the necessary libraries in the archive artifact like today