### PR TITLE
Fix for a changed gamedata folder for both D1 and D2 on Steam.

### DIFF
--- a/engines/dxx-rebirth/assets/run-d1x.sh
+++ b/engines/dxx-rebirth/assets/run-d1x.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 
-LD_LIBRARY_PATH="lib:$LD_LIBRARY_PATH" ./d1x-rebirth -hogdir .
+HOGDIR=./descent
+LD_LIBRARY_PATH="lib:$LD_LIBRARY_PATH" ./d1x-rebirth -hogdir "$HOGDIR"
+

--- a/engines/dxx-rebirth/assets/run-d2x.sh
+++ b/engines/dxx-rebirth/assets/run-d2x.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 
-LD_LIBRARY_PATH="lib:$LD_LIBRARY_PATH" ./d2x-rebirth -hogdir .
+HOGDIR=./descent2
+LD_LIBRARY_PATH="lib:$LD_LIBRARY_PATH" ./d2x-rebirth -hogdir "$HOGDIR"
+


### PR DESCRIPTION
<!-- You can remove any parts of this template that do not apply to your changes -->

### Common Code Submissions

* [y] Have you verified that the changes are isolated to the features or fixes you are wanting to do?
* [y] Have you tested at least one of the engines to ensure that your changes do not break existing workflow?
* [y] Have you described what your changes are accomplishing? 

More context: both Descent games got an update lately (among other things it seems to introduce a native DOSBox executable for Linux, you can see it on SteamDB in detail) that broke both launchers for DXX-Rebirth engine since .hog files got moved to '/descent/' and '/descent2/' directories along with other gamedata files. This PR fixes it by pointing engines to the corresponding new directory.