### PR TITLE
ja2-stracciatella: Revert from legacy backticks to using $(...)

### DIFF
--- a/engines/ja2-stracciatella/assets/run-ja2.sh
+++ b/engines/ja2-stracciatella/assets/run-ja2.sh
@@ -4,7 +4,7 @@ wantedversion="0.18.0"
 filepath="./ja2-stracciatella_0.18.0-git+ebc73ce_x86-64.AppImage"
 
 if [ -f "readyversion.txt" ]; then
-    readyversion=`cat readyversion.txt`
+    readyversion=$(cat readyversion.txt)
     echo "Found version: $readyversion"
 else
     echo "No Version Found"


### PR DESCRIPTION
<!-- You can remove any parts of this template that do not apply to your changes -->
# Description
First PR among the set of five PRs aimed at fixing issue #517. This PR changes all the use of backticks for command substitution under the `ja2-stracciatella` engine.

Chose this engine to be part of the first PR because it has the least number of recurrences of backticks.

### Common Code Submissions

* [x] Have you verified that the changes are isolated to the features or fixes you are wanting to do?
* [x] Have you tested at least one of the engines to ensure that your changes do not break existing workflow?
* [x] Have you described what your changes are accomplishing? 
