### PR TITLE
metastasis: Revert from legacy backticks to using $(...)

### DIFF
--- a/engines/source-sdk-2013/assets/metastasis/run-metastasis.sh
+++ b/engines/source-sdk-2013/assets/metastasis/run-metastasis.sh
@@ -81,21 +81,21 @@ if [[ ! -z "${DEPPATH_243730}" ]]; then
     sdkpath="$DEPPATH_243730"
     echo "Automatically detected sdkpath at $sdkpath"
 else
-    sdkpath=`cat sdkpath.txt`
+    sdkpath=$(cat sdkpath.txt)
 fi
 
 if [[ ! -z "${DEPPATH_1070560}" ]]; then
     runtimepath="$DEPPATH_1070560"
     echo "Automatically detected runtimepath at $runtimepath"
 else
-    runtimepath=`cat runtimepath.txt`
+    runtimepath=$(cat runtimepath.txt)
 fi
 
 if [[ ! -z "${DEPPATH_380}" ]]; then
     EPISODE_PATH="$DEPPATH_380"
     echo "Automatically detected hlpath at $EPISODE_PATH"
 else
-    EPISODE_PATH=`cat hlpath.txt`
+    EPISODE_PATH=$(cat hlpath.txt)
 fi
 
 pushd "metastasis"


### PR DESCRIPTION
Fourth PR among the set of five PRs aimed at fixing issue #517. This PR changes all the use of backticks for command substitution in metastasist under the assets of source-sdk-123 engine.

### Common Code Submissions

* [x] Have you verified that the changes are isolated to the features or fixes you are wanting to do?
* [x] Have you tested at least one of the engines to ensure that your changes do not break existing workflow?
* [x] Have you described what your changes are accomplishing? 
