### PR TITLE
eduke32 - Fixed addon selection for Megaton Edition

### DIFF
--- a/engines/eduke32/assets/run-eduke32-megaton.sh
+++ b/engines/eduke32/assets/run-eduke32-megaton.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+gamearg="$1"
+gamenum="$2"
+
+if [ -z $1 ]; then
+    ./eduke32 -usecwd -nosetup
+elif [ "$gamenum" = "1" ]; then
+    ./eduke32 -j addons/dc -usecwd -nosetup -addon 1
+elif [ "$gamenum" = "2" ]; then
+    ./eduke32 -j addons/nw -usecwd -nosetup -addon 2
+elif [ "$gamenum" = "3" ]; then
+    ./eduke32 -j addons/vacation -usecwd -nosetup -addon 3
+else
+    ./eduke32 -usecwd -nosetup
+fi

--- a/metadata/packagesruntime.json
+++ b/metadata/packagesruntime.json
@@ -2203,7 +2203,7 @@
         "choices": [
             {
                 "name": "eduke32",
-                "command": "./run-eduke32.sh",
+                "command": "./run-eduke32-megaton.sh",
                 "download": [
                     "eduke32"
                 ]


### PR DESCRIPTION
### Common Code Submissions

* [x] Have you verified that the changes are isolated to the features or fixes you are wanting to do?
* [x] Have you tested at least one of the engines to ensure that your changes do not break existing workflow?
* [x] Have you described what your changes are accomplishing? 

Hello everyone,

here's the PR to fix playing the addons using eduke32 on the DN3D Megaton Edition.

I created a new run-eduke32-megaton.sh runner and added it to the packagesruntime.json

Similar to the previous issue with raze (#561 and #560 ) eduke32 was executed from within gameroot and added gameroot to edukes search patch. Like: `gameroot/gameroot` and `gammeroot/gameroot/addons/[nw,dc,vacation]` which resulted in none of the addons being found.

The main game ran fine because eduke32 was next to the necessary files and did solely not picked up the addons correctly.

This should fix this :)

Kind regards,
Vortex.