### PR TITLE
buildgdx -Add OneUnitWholeBlood

### DIFF
--- a/engines/buildgdx/assets/run-buildgdx-blood.sh
+++ b/engines/buildgdx/assets/run-buildgdx-blood.sh
@@ -3,6 +3,11 @@
 gamepath="$PWD"
 configpath=~/M210Projects/BloodGDX/bloodgdx.ini
 mkdir -p ~/M210Projects/BloodGDX
+
+if [[ $gamepath == *"One Unit Whole Blood"* ]]; then
+    configpath=~/M210Projects/BloodGDX/oneunitgdx.ini
+fi
+
 echo "$configpath"
 
 if [ ! -f ${configpath} ]; then

--- a/engines/buildgdx/env.sh
+++ b/engines/buildgdx/env.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export STEAM_APP_ID_LIST="1655410 1655430 329650 1010750 1260020"
+export STEAM_APP_ID_LIST="1655410 1655430 299030 329650 1010750 1260020"
 export LICENSE_PATH="./source/apache.txt"
 export ADDITIONAL_LICENSES="./source/buildlic.txt ./source/gpl3.txt"
 export LIBRARIES="openjdk11"

--- a/engines/dosbox-staging/env.sh
+++ b/engines/dosbox-staging/env.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export STEAM_APP_ID_LIST="default 7650 7660 7760 410970"
+export STEAM_APP_ID_LIST="default 7650 7660 7760 299030 410970"
 export LICENSE_PATH="./source/COPYING"
 export COMMON_PACKAGE="1"
 export ADDITIONAL_LICENSES="./source/subprojects/fluidsynth-2.2.0/LICENSE ./source/subprojects/munt-libmt32emu_2_5_0/LICENSE.build"

--- a/engines/dosbox-staging/env.sh
+++ b/engines/dosbox-staging/env.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export STEAM_APP_ID_LIST="default 7650 7660 7760 299030 410970"
+export STEAM_APP_ID_LIST="default 7650 7660 7760 410970"
 export LICENSE_PATH="./source/COPYING"
 export COMMON_PACKAGE="1"
 export ADDITIONAL_LICENSES="./source/subprojects/fluidsynth-2.2.0/LICENSE ./source/subprojects/munt-libmt32emu_2_5_0/LICENSE.build"

--- a/metadata/packagesruntime.json
+++ b/metadata/packagesruntime.json
@@ -2760,6 +2760,30 @@
                 "url": "https://github.com/luxtorpeda-dev/packages/releases/download/raze-25/",
                 "file": "raze-common-25.tar.xz",
                 "cache_by_name": true
+            },
+            {
+                "name": "openjdk11",
+                "url": "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.12%2B7/",
+                "file": "OpenJDK11U-jdk_x64_linux_hotspot_11.0.12_7.tar.gz",
+                "cache_by_name": true
+            },
+            {
+                "name": "buildgdx-lib",
+                "url": "https://m210.duke4.net/index.php/downloads/send/8-java/",
+                "file": "54-buildgdx",
+                "cache_by_name": true
+            },
+            {
+                "name": "buildgdx",
+                "url": "https://github.com/luxtorpeda-dev/packages/releases/download/buildgdx-1/",
+                "file": "buildgdx-common-1.tar.xz",
+                "cache_by_name": true
+            },
+            {
+                "name": "dosbox-staging",
+                "url": "https://github.com/luxtorpeda-dev/packages/releases/download/dosbox-staging-12/",
+                "file": "dosbox-staging-common-12.tar.xz",
+                "cache_by_name": true
             }
         ],
         "choices": [
@@ -2793,6 +2817,32 @@
                     "raze"
                 ],
                 "engine_name": "raze"
+            },
+            {
+                "name": "BuildGDX",
+                "command": "./run-buildgdx-blood.sh",
+                "download": [
+                    "openjdk11",
+                    "buildgdx-lib",
+                    "buildgdx"
+                ],
+                "download_config": {
+                    "buildgdx-lib": {
+                        "decode_as_zip": true
+                    },
+                    "openjdk11": {
+                        "extract_location": "./jdk-11.0.12",
+                        "strip_prefix": "jdk-11.0.12+7/"
+                    }
+                }
+            },
+            {
+                "name": "dosbox-staging",
+                "command": "./dosbox-staging/run-dosbox-staging.sh",
+                "use_original_command_directory": true,
+                "download": [
+                    "dosbox-staging"
+                ]
             }
         ]
     },
@@ -3427,7 +3477,7 @@
             },
             {
                 "name": "BuildGDX",
-                "command": "./run-buildgdx-bloodfresh.sh",
+                "command": "./run-buildgdx-blood.sh",
                 "download": [
                     "openjdk11",
                     "buildgdx-lib",

--- a/metadata/packagesruntime.json
+++ b/metadata/packagesruntime.json
@@ -2778,12 +2778,6 @@
                 "url": "https://github.com/luxtorpeda-dev/packages/releases/download/buildgdx-1/",
                 "file": "buildgdx-common-1.tar.xz",
                 "cache_by_name": true
-            },
-            {
-                "name": "dosbox-staging",
-                "url": "https://github.com/luxtorpeda-dev/packages/releases/download/dosbox-staging-12/",
-                "file": "dosbox-staging-common-12.tar.xz",
-                "cache_by_name": true
             }
         ],
         "choices": [
@@ -2835,14 +2829,6 @@
                         "strip_prefix": "jdk-11.0.12+7/"
                     }
                 }
-            },
-            {
-                "name": "dosbox-staging",
-                "command": "./dosbox-staging/run-dosbox-staging.sh",
-                "use_original_command_directory": true,
-                "download": [
-                    "dosbox-staging"
-                ]
             }
         ]
     },


### PR DESCRIPTION
Adds buildgdx engine to One Unit Whole Blood

The current buildgdx script for Fresh Supply was already working fine for One Unit, I just made them use different configuration files and renamed the script to a more generic name.