### PR TITLE
[1oom] Added a fix for uppercase vs lowercase workdir name

### DIFF
--- a/metadata/packagesruntime.json
+++ b/metadata/packagesruntime.json
@@ -3796,6 +3796,7 @@
             {
                 "name": "1oom",
                 "command": "../run-1oom.sh",
+                "use_original_command_directory": true,
                 "download": [
                     "1oom"
                 ]


### PR DESCRIPTION
Added a fix for uppercase (as in Windows/DOS filesystems) vs lowercase (as in Unix-like OS filesystems) workdir name, sometimes resulting in 1oom being installed into a wrong directory and failing to launch.

### Common Code Submissions

* [x] Have you verified that the changes are isolated to the features or fixes you are wanting to do?
* [x] Have you tested at least one of the engines to ensure that your changes do not break existing workflow?
* [x] Have you described what your changes are accomplishing? 
