### PR TITLE
OpenGothic - Add Gothic 1 Support

### DIFF
--- a/engines/opengothic/assets/run-gothic1.sh
+++ b/engines/opengothic/assets/run-gothic1.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if [ ! -f Gothic.ini ]; then
+    cp system/Gothic.ini GOTHIC.ini
+fi
+
+LD_LIBRARY_PATH="lib:$LD_LIBRARY_PATH" ./bin/Gothic2Notr -g1 -g . -nofrate

--- a/engines/opengothic/assets/run-gothic1.sh
+++ b/engines/opengothic/assets/run-gothic1.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ ! -f Gothic.ini ]; then
-    cp system/Gothic.ini GOTHIC.ini
+    cp system/GOTHIC.INI Gothic.ini
 fi
 
 LD_LIBRARY_PATH="lib:$LD_LIBRARY_PATH" ./bin/Gothic2Notr -g1 -g . -nofrate

--- a/engines/opengothic/assets/run-gothic2.sh
+++ b/engines/opengothic/assets/run-gothic2.sh
@@ -4,4 +4,4 @@ if [ ! -f Gothic.ini ]; then
     cp system/Gothic.ini Gothic.ini
 fi
 
-LD_LIBRARY_PATH="lib:$LD_LIBRARY_PATH" ./bin/Gothic2Notr -g . -nofrate
+LD_LIBRARY_PATH="lib:$LD_LIBRARY_PATH" ./bin/Gothic2Notr -g2 -g . -nofrate

--- a/engines/opengothic/build.sh
+++ b/engines/opengothic/build.sh
@@ -25,6 +25,16 @@ cmake --build ./build --target all
 popd
 
 # COPY PHASE
+# Gothic 1
+mkdir "$diststart/65540/dist/lib/"
+mkdir "$diststart/65540/dist/bin/"
+
+cp -rfv "source/build/opengothic/Gothic2Notr" "$diststart/65540/dist/bin/Gothic2Notr"
+cp -rfv "source/build/opengothic/Gothic2Notr.sh" "$diststart/65540/dist/Gothic2Notr.sh"
+cp -rfv source/build/opengothic/*.so* "$diststart/65540/dist/lib/"
+cp -rfv assets/run-gothic1.sh "$diststart/65540/dist/run-gothic1.sh"
+
+# Gothic 2
 mkdir "$diststart/39510/dist/lib/"
 mkdir "$diststart/39510/dist/bin/"
 

--- a/engines/opengothic/env.sh
+++ b/engines/opengothic/env.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-export STEAM_APP_ID_LIST="39510"
+export STEAM_APP_ID_LIST="65540 39510"
 export LICENSE_PATH="./source/LICENSE"

--- a/metadata/packagesruntime.json
+++ b/metadata/packagesruntime.json
@@ -3754,6 +3754,19 @@
             }
         ]
     },
+    "65540": {
+        "game_name": "Gothic 1",
+        "download": [
+            {
+                "name": "opengothic",
+                "url": "https://github.com/luxtorpeda-dev/packages/releases/download/opengothic-20/",
+                "file": "opengothic-39510-20.tar.xz"
+            }
+        ],
+        "command": "./run-gothic1.sh",
+        "engine_name": "OpenGothic",
+        "cloudNotAvailable": true
+    },
     "39510": {
         "game_name": "Gothic 2: Gold Edition",
         "download": [


### PR DESCRIPTION
Adds support for Gothic 1 using OpenGothic, uses the same engine and scripts as Gothic 2 Gold.
Additionally adds the `-g1` and `-g2` switches when launching OpenGothic so it knows if it's playing Gothic 1 or Gothic 2.  

I haven't tried building it but it's nearly the same as G2 so I think it should work. I have tried running it by copying OpenGothic from the G2 directory and modifying the start script and everything worked fine