### PR TITLE
ecwolf - Update to latest & Wolfenstein 3D (2270): Support Spear of Destiny.

### DIFF
--- a/engines/ecwolf/assets/run-ecwolf-wolf3d.sh
+++ b/engines/ecwolf/assets/run-ecwolf-wolf3d.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+originalpwd="$PWD"
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+cd "$DIR"
+
+if ! [[ -z "${LUX_STEAM_DECK}" ]]; then
+    if [ ! -f ecwolf.cfg ]; then
+        echo -e "Vid_FullScreen = 1;" >> ecwolf.cfg
+        echo -e "FullScreenWidth = 1280;" >> ecwolf.cfg
+        echo -e "FullScreenHeight = 800;" >> ecwolf.cfg
+    fi
+fi
+./ecwolf --config ecwolf.cfg "$@"
+

--- a/engines/ecwolf/assets/run-ecwolf.sh
+++ b/engines/ecwolf/assets/run-ecwolf.sh
@@ -28,6 +28,7 @@ if [ -d "base" ]; then
     fi
     
 else
+    cd "$(dirname "$0")"
     if ! [[ -z "${LUX_STEAM_DECK}" ]]; then
         if [ ! -f ecwolf.cfg ]; then
             echo -e "Vid_FullScreen = 1;" >> ecwolf.cfg
@@ -35,6 +36,6 @@ else
             echo -e "FullScreenHeight = 800;" >> ecwolf.cfg
         fi
     fi
-    ./ecwolf --config ecwolf.cfg
+    ./ecwolf --config ecwolf.cfg "$@"
 fi
 

--- a/engines/ecwolf/assets/run-ecwolf.sh
+++ b/engines/ecwolf/assets/run-ecwolf.sh
@@ -28,7 +28,6 @@ if [ -d "base" ]; then
     fi
     
 else
-    cd "$(dirname "$0")"
     if ! [[ -z "${LUX_STEAM_DECK}" ]]; then
         if [ ! -f ecwolf.cfg ]; then
             echo -e "Vid_FullScreen = 1;" >> ecwolf.cfg
@@ -36,6 +35,6 @@ else
             echo -e "FullScreenHeight = 800;" >> ecwolf.cfg
         fi
     fi
-    ./ecwolf --config ecwolf.cfg "$@"
+    ./ecwolf --config ecwolf.cfg
 fi
 

--- a/engines/ecwolf/build.sh
+++ b/engines/ecwolf/build.sh
@@ -3,7 +3,7 @@
 # CLONE PHASE
 git clone https://bitbucket.org/ecwolf/ecwolf.git source
 pushd source
-git checkout ac4a229
+git checkout 178ef0f
 popd
 
 # BUILD PHASE

--- a/engines/ecwolf/env.sh
+++ b/engines/ecwolf/env.sh
@@ -3,3 +3,4 @@
 export STEAM_APP_ID_LIST="2270 9000 371180"
 export LICENSE_PATH="./source/docs/copyright"
 export COMMON_PACKAGE="1"
+export LIBRARIES="sdl2mixer"

--- a/metadata/packagesruntime.json
+++ b/metadata/packagesruntime.json
@@ -252,8 +252,34 @@
                 "cache_by_name": true
             }
         ],
-        "command": "./run-ecwolf.sh",
-        "engine_name": "ecwolf",
+        "choices": [
+            {
+                "name": "ecwolf: Wolfenstein 3D",
+                "command": "./base/run-ecwolf.sh",
+                "download": [
+                    "ecwolf"
+                ],
+                "download_config": {
+                    "ecwolf": {
+                        "extract_location": "./base"
+                    }
+                },
+                "engine_name": "ecwolf"
+            },
+            {
+                "name": "ecwolf: Spear of Destiny",
+                "command": "./base/m1/run-ecwolf.sh",
+                "download": [
+                    "ecwolf"
+                ],
+                "download_config": {
+                    "ecwolf": {
+                        "extract_location": "./base/m1"
+                    }
+                },
+                "engine_name": "ecwolf"
+            }
+        ],
         "cloudAvailable": true
     },
     "2280": {

--- a/metadata/packagesruntime.json
+++ b/metadata/packagesruntime.json
@@ -255,28 +255,26 @@
         "choices": [
             {
                 "name": "ecwolf: Wolfenstein 3D",
-                "command": "./base/run-ecwolf.sh",
+                "command": "./run-ecwolf-wolf3d.sh",
+                "command_args": [
+                    "--data",
+                    "WL6"
+                ],
                 "download": [
                     "ecwolf"
                 ],
-                "download_config": {
-                    "ecwolf": {
-                        "extract_location": "./base"
-                    }
-                },
                 "engine_name": "ecwolf"
             },
             {
                 "name": "ecwolf: Spear of Destiny",
-                "command": "./base/m1/run-ecwolf.sh",
+                "command": "./run-ecwolf-wolf3d.sh",
+                "command_args": [
+                    "--data",
+                    "SOD"
+                ],
                 "download": [
                     "ecwolf"
                 ],
-                "download_config": {
-                    "ecwolf": {
-                        "extract_location": "./base/m1"
-                    }
-                },
                 "engine_name": "ecwolf"
             }
         ],


### PR DESCRIPTION
Back in September, Bethesda repackaged Spear of Destiny alongside Wolfenstein 3D and subsequently delisted the standalone version (9000).  This adds support for the bundled version of Spear of Destiny on the engine selection screen.

Unfortunately Bethesda did not include the mission packs in this version, but users could add them manually and pass the ecwolf "--data" parameter in a user-packages.json override.

In addition to the changes here, the ecwolf package will need to be rebuilt with an appropriate version bump.