### PR TITLE
Fix De.u and De.int Casing

### DIFF
--- a/engines/ut99/assets/setup-ut99-469c.sh
+++ b/engines/ut99/assets/setup-ut99-469c.sh
@@ -34,6 +34,8 @@ fi
 
 cp -rfv linuxdata-469c/System/* linuxdata-469c/System64
 
+ln -rsf linuxdata-469c/System64/de.u linuxdata-469c/System64/De.u
+ln -rsf linuxdata-469c/System64/de.int linuxdata-469c/System64/De.int
 ln -rsf linuxdata-469c/System64/multimesh.u linuxdata-469c/System64/MultiMesh.u
 ln -rsf linuxdata-469c/System64/multimesh.int linuxdata-469c/System64/MultiMesh.int
 


### PR DESCRIPTION
Based on the fact that the default UnrealTournament.ini lists this as `ServerPackages=De` in the `[Engine.GameEngine]` section.
Just tried to do the same fix as what was done with MultiMesh.
If De isn't this case, hosting a server fails.
As far as I can tell, there aren't any other files with a wrong case.

Thank you for including Bonus Pack 4 in this package!


### Common Code Submissions

* [x] Have you verified that the changes are isolated to the features or fixes you are wanting to do?
* [ ] Have you tested at least one of the engines to ensure that your changes do not break existing workflow?
* [x] Have you described what your changes are accomplishing? 
