### PR TITLE
DREAMM: Installer to enable Indiana Jones and the Last Crusade

### DIFF
--- a/engines/dreamm/assets/run-dreamm-ij_lc.sh
+++ b/engines/dreamm/assets/run-dreamm-ij_lc.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Define the target directory
+target_directory="install/lec-indy3-vga/pc-2.0-classic/"
+
+# Check if the target directory exists
+if [ -d "$target_directory" ]; then
+    echo "Directory $target_directory already exists. Skipping installation."
+else
+    # Use DREAMM in portable mode
+    touch config.json
+
+    # Directory doesn't exist, proceed with the installation
+    yes | ./dreamm -install "."
+
+    # Check if the installation was successful
+    if [ $? -eq 0 ]; then
+        echo "Installation completed successfully."
+    else
+        echo "Installation failed."
+    fi
+fi
+
+./dreamm "$target_directory"

--- a/engines/dreamm/env.sh
+++ b/engines/dreamm/env.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-export STEAM_APP_ID_LIST="default 730830 904540 557240"
+export STEAM_APP_ID_LIST="default 730830 904540 557240 32310"
 export COMMON_PACKAGE="1"

--- a/metadata/packagessniper_v2.json
+++ b/metadata/packagessniper_v2.json
@@ -7771,6 +7771,27 @@
             "app_id": "904540"
         },
         {
+            "game_name": "Indiana Jones® and the Last Crusade™",
+            "download": [
+                {
+                    "name": "dreamm-binaries",
+                    "url": "https://aarongiles.com/dreamm/releases/",
+                    "file": "dreamm-2.1-linux-x64.tgz",
+                    "cache_by_name": true
+                },
+                {
+                    "name": "dreamm",
+                    "url": "https://github.com/luxtorpeda-dev/packages/releases/download/dreamm-5/",
+                    "file": "dreamm-common-5.tar.xz",
+                    "cache_by_name": true
+                }
+            ],
+            "command": "./run-dreamm-ij_lc.sh",
+            "engine_name": "DREAMM",
+            "cloudNotAvailable": true,
+            "app_id": "32310"
+        },
+        {
             "game_name": "Afterlife",
             "download": [
                 {


### PR DESCRIPTION
After some trial and error I found out that this game was missing some files that could be fixed by installing it with DREAMM. It uses DREAMMs Portabel Mode to install it in the same folder. 

I'm not sure if the metadata in packagesniper2.json will update dreamm-5 automatically to the new one, which I guess will be 6, if not maybe you could help fix that so it gets the new files.

### New Engine Package Submissions

* [ ] Have you followed the instructions in the build documentation?
* [ ] Have you run the build locally and ensured the package allowed you to launch and play the Steam game?
* [x] Have you updated the packages.json file?
* [x] Have you ensured that there is not already a pull request or active engine package for the one you are adding?


### Common Code Submissions

* [x] Have you verified that the changes are isolated to the features or fixes you are wanting to do?
* [x] Have you tested at least one of the engines to ensure that your changes do not break existing workflow?
* [x] Have you described what your changes are accomplishing? 
