### PR TITLE
custom-archive-formats

### DIFF
--- a/common/lib.sh
+++ b/common/lib.sh
@@ -199,12 +199,13 @@ copy_license_file () {
 }
 
 create_archives () {
+    ARCHIVE_FORMAT="${ARCHIVE_FORMAT:-v7}"
     if [ -z "${COMMON_PACKAGE}" ]; then
         for app_id in $STEAM_APP_ID_LIST ; do
             filename="$ENGINE_NAME-$app_id"
             pushd "$app_id" || exit 1
             tar \
-                --format=v7 \
+                --format="${ARCHIVE_FORMAT}" \
                 --mode='a+rwX,o-w' \
                 --owner=0 \
                 --group=0 \
@@ -221,7 +222,7 @@ create_archives () {
         filename="$ENGINE_NAME-common"
         pushd "common" || exit 1
         tar \
-            --format=v7 \
+            --format="${TAR_FORMAT}" \
             --mode='a+rwX,o-w' \
             --owner=0 \
             --group=0 \

--- a/common/package.sh
+++ b/common/package.sh
@@ -10,7 +10,7 @@ log_environment
 popd
 
 pushd "dist"
-if [ -z "${ARCHIVE_WITHOUT_V7}" ]; then
+if [ -z "${ARCHIVE_WITHOUT_V7}" ] && [ -z "${ARCHIVE_WITHOUT_FORMAT}" ]; then
     create_archives
 else
     create_archives_without_v7


### PR DESCRIPTION
Added a possibility to specify a custom tar format via `ARCHIVE_FORMAT` env var. I made sure to keep existing options and defaults intact.

Reason for this is that Cortex Command has very long paths for Data, exceeding 99 character limit with both v7 and no format. This allows to package CC Data properly without error or truncating, and works properly, during build, extraction and the game runs as expected.

This is a blocker for CCCP engine addition.

### Common Code Submissions

* [X] Have you verified that the changes are isolated to the features or fixes you are wanting to do?
* [X] Have you tested at least one of the engines to ensure that your changes do not break existing workflow?
* [X] Have you described what your changes are accomplishing? 
